### PR TITLE
Fix bug where the room state cannot be retrieved.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Room states changelog
 
+## NEXT
+
+* Not published yet
+
+### Changes
+
+* Fix bug where the room state cannot be retrieved. This affects an Android app which uses obfuscation via ProGuard/R8.
+  * Error: `IllegalArgumentException: Unable to create call adapter for retrofit2.Call<kotlin.Result>`
+  * Related: https://github.com/skydoves/retrofit-adapters/issues/24
+
+
 ## [v.1.0.0](https://github.com/EventFahrplan/roomstates/releases/tag/v.1.0.0)
 
 * Published: 2025-01-14

--- a/room-states-base/src/main/resources/META-INF/proguard/room-states.pro
+++ b/room-states-base/src/main/resources/META-INF/proguard/room-states.pro
@@ -1,0 +1,1 @@
+-keep public class kotlin.Result { *; }


### PR DESCRIPTION
# Description
+ This affects an Android app which uses obfuscation via ProGuard/R8.
+ Error: `IllegalArgumentException: Unable to create call adapter for retrofit2.Call<kotlin.Result>`
+ Related: https://github.com/skydoves/retrofit-adapters/issues/24

# Stacktrace

``` java
java.lang.IllegalArgumentException: Unable to create call adapter for retrofit2.Call<kotlin.Result>
    for method RoomStatesService.getRooms-gIAlu-s
	at retrofit2.Utils.methodError(Utils.java:56)
	at retrofit2.HttpServiceMethod.createCallAdapter(HttpServiceMethod.java:129)
	at retrofit2.HttpServiceMethod.parseAnnotations(HttpServiceMethod.java:78)
	at retrofit2.ServiceMethod.parseAnnotations(ServiceMethod.java:39)
	at retrofit2.Retrofit.loadServiceMethod(Retrofit.java:235)
	at retrofit2.Retrofit$1.invoke(Retrofit.java:177)
	at java.lang.reflect.Proxy.invoke(Proxy.java:1006)
	at $Proxy2.getRooms-gIAlu-s(Unknown Source)
	at info.metadude.kotlin.library.roomstates.repositories.simple.SimpleRoomStatesRepository$getRooms$2.invokeSuspend(SimpleRoomStatesRepository.kt:22)
	at info.metadude.kotlin.library.roomstates.repositories.simple.SimpleRoomStatesRepository$getRooms$2.invoke(SimpleRoomStatesRepository.kt:0)
	at info.metadude.kotlin.library.roomstates.repositories.simple.SimpleRoomStatesRepository$getRooms$2.invoke(SimpleRoomStatesRepository.kt:0)
	...

Caused by: java.lang.ClassCastException: java.lang.Class cannot be cast to java.lang.reflect.ParameterizedType
	at com.skydoves.retrofit.adapters.result.ResultCallAdapterFactory.get(ResultCallAdapterFactory.kt:58)
	at retrofit2.Retrofit.nextCallAdapter(Retrofit.java:309)
	at retrofit2.Retrofit.callAdapter(Retrofit.java:293)
	at retrofit2.HttpServiceMethod.createCallAdapter(HttpServiceMethod.java:127)
	...
```